### PR TITLE
docs: simplify structure

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,6 @@ theme:
   features:
   - navigation.instant # Make MkDocs behave like a Single Page Application (SPA).
   - navigation.tabs # Enables navigational tabs at top of page.
-  - navigation.indexes # Enables use of "index.md" pages.
   - navigation.top # Enables "back-to-top" button.
   - navigation.footer # Enables "previous" and "next" navigation buttons in footer
 
@@ -46,17 +45,8 @@ markdown_extensions:
 
 nav:
   - Home:
-    - index.md
-    - best-practices.md
-    - module-library.md
-  - Get started:
-    - get-started/index.md
-    - get-started/prerequisites.md
-    - get-started/syntax.md
-    - get-started/create-resources.md
-    - get-started/update-resources.md
-    - get-started/destroy-resources.md
-    - get-started/summary.md
-  - Reusable modules:
-    - reusable-modules/index.md
-    - reusable-modules/usage-examples.md
+    - Overview: index.md
+  - Best practices:
+    - Overview: best-practices.md
+  - Module library:
+    - Overview: module-library.md


### PR DESCRIPTION
Simplifies the structure of the page, putting the focus on the main features in Terraform Baseline: best practices and the module library.

![image](https://github.com/equinor/terraform-baseline/assets/46495473/0842e492-b4d9-4e98-857e-1a10a8508b8d)
