### PR TITLE
docs: add topic `terraform-module` to module repos

### DIFF
--- a/docs/best-practices/repository.md
+++ b/docs/best-practices/repository.md
@@ -31,4 +31,4 @@
     **/CODEOWNERS @equinor/terraform-baseline-admins
     ```
 
-- Add topic `terraform-baseline` to the repository.
+- Add topics `terraform-baseline` and `terraform-module` to the repository.

--- a/scripts/configure_repo.sh
+++ b/scripts/configure_repo.sh
@@ -10,6 +10,7 @@ default_branch="main"
 gh repo edit "$repo" \
   --homepage "https://registry.terraform.io/modules/equinor/$module_name/azurerm/latest" \
   --add-topic "terraform-baseline" \
+  --add-topic "terraform-module" \
   --enable-wiki=false \
   --enable-issues=false \
   --enable-projects=false \


### PR DESCRIPTION
Allows us to use filter for topics `terraform-baseline` and `terraform-module` to get all Terraform Baseline modules.