### PR TITLE
chore: restructure navigation

### DIFF
--- a/docs/best-practices/index.md
+++ b/docs/best-practices/index.md
@@ -1,3 +1,0 @@
-# Best practices
-
-This section provides best practices for developing reusable Terraform modules in Equinor.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,8 +10,6 @@ theme:
     repo: fontawesome/brands/github
   features:
   - navigation.instant # Make MkDocs behave like a Single Page Application (SPA).
-  - navigation.tabs # Enables navigational tabs at top of page.
-  - navigation.indexes # Enables use of "index.md" pages.
   - navigation.top # Enables "back-to-top" button.
   - navigation.footer # Enables "previous" and "next" navigation buttons in footer
   - content.action.edit # Enables "Edit this page" button.
@@ -32,7 +30,6 @@ theme:
         icon: material/weather-night
         name: Switch to light mode
 
-
 markdown_extensions:
   - toc:
       permalink: true
@@ -42,10 +39,8 @@ markdown_extensions:
   - attr_list # Open links in new tabs by using syntax [<text>](<url>){target=_blank}.
 
 nav:
-  - Home:
-    - Overview: index.md
+  - Overview: index.md
   - Best practices:
-    - best-practices/index.md
     - best-practices/repository.md
     - best-practices/resources.md
     - best-practices/variables-and-outputs.md


### PR DESCRIPTION
Remove navigation tabs. It's not a complex site anyway with multiple levels of nested documents, so might as well keeps things simple.

## Before

Home, best practices and module library in separate tabs, so you have to open a new page to see the documents under each tab:

![image](https://github.com/equinor/terraform-baseline/assets/46495473/7801d75f-3bb0-4d12-ac49-85631233cd2d)

## After

Home, best practices and module library in a single tab, so you can see all documents on a single tab:

![image](https://github.com/equinor/terraform-baseline/assets/46495473/66380b27-e6b5-48fe-927e-50c94ae0a2c2)
