### PR TITLE
ci(daily): add run-name and update workflow path

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,4 +1,5 @@
 name: Daily actions
+run-name: Daily actions
 
 on:
   schedule:
@@ -7,7 +8,7 @@ on:
 jobs:
   stale:
     name: Stale
-    uses: equinor/terraform-baseline/.github/workflows/stale.yml
+    uses: ./.github/workflows/stale.yml
     with:
       days-before-stale: 60
       days-before-close: 14


### PR DESCRIPTION
Added `run-name` for cosmetic reasons, looks better in the Actions tab, and updated the `jobs.stale.uses:` path to use the correct syntax for reusable workflows located in the same repository.

Ref.: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_iduses