### PR TITLE
docs: link directly to modules overview

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,4 +52,4 @@ nav:
     - best-practices/variables-and-outputs.md
     - best-practices/meta-arguments.md
     - best-practices/testing.md
-  - Module library: https://registry.terraform.io/namespaces/equinor
+  - Module library: https://registry.terraform.io/search/modules?namespace=equinor


### PR DESCRIPTION
Now that the Terraform Registry search functionality seems to be fixed and always shows the correct number of modules, link directly to a search of all modules in the Equinor namespace, instead of to the Equinor namespace overview (which includes both modules and providers).