### PR TITLE
chore: only allow maintainers to approve PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ A contributor should:
 A maintainer must:
 
 - Be a member of the [@equinor/terraform-baseline-maintainers](https://github.com/orgs/equinor/teams/terraform-baseline-maintainers) team.
-- Review and approve pull requests in all Terraform Baseline repositories.
+- Review, approve and merge pull requests in all Terraform Baseline repositories.
 - Discuss and update best practices when needed.
 
 A maintainer should:

--- a/scripts/branch_protection.json
+++ b/scripts/branch_protection.json
@@ -9,7 +9,11 @@
     "require_last_push_approval": true,
     "bypass_pull_request_allowances": {}
   },
-  "restrictions": null,
+  "restrictions": {
+    "users": [],
+    "teams": [],
+    "apps": []
+  },
   "required_linear_history": true,
   "allow_force_pushes": false,
   "allow_deletions": false,


### PR DESCRIPTION
Explicitly setting the properties of `restrictions` to empty lists allows only users with role `Mantain` to merge PRs. This is what it looks like on GitHub under branch protection settings for branch `main`:

![bilde](https://github.com/user-attachments/assets/feac51ed-0eda-4cef-a34a-197ed55d040d)

Contributors with the `Write` role will be blocked by the following message:

![bilde](https://github.com/user-attachments/assets/65807764-1003-4251-a910-af3639bb394c)

Closes #187.